### PR TITLE
Add support for Zig package manager + update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 This is a Zig library for working with [The Limine Boot Protocol](https://github.com/limine-bootloader/limine/blob/trunk/PROTOCOL.md).
 You can find an example barebones kernel using this library [here](https://github.com/limine-bootloader/limine-zig-barebones).
 
-To use this library you need the latest stage 2/3 Zig compiler. For instructions on how to build one please refer to [this wiki page.](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source)
+To use this library, you need at least Zig 0.11.x.

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    _ = b.addModule("limine", .{ .source_file = .{ .path = "limine.zig" } });
+}


### PR DESCRIPTION
- Added support for the Zig package manager with a simple build.zig file.
- Updated README.md to include Zig 0.11.x release as minimum required.