### PR TITLE
Fix SMP info structure for individual CPUs

### DIFF
--- a/limine.zig
+++ b/limine.zig
@@ -330,9 +330,9 @@ const AArch64SmpResponse = extern struct {
     flags: u32,
     bsp_mpidr: u64,
     cpu_count: u64,
-    cpus_ptr: [*]*X86SmpInfo,
+    cpus_ptr: [*]*AArch64SmpInfo,
 
-    pub inline fn cpus(self: *@This()) []*X86SmpInfo {
+    pub inline fn cpus(self: *@This()) []*AArch64SmpInfo {
         return self.cpus_ptr[0..self.cpu_count];
     }
 };
@@ -352,9 +352,9 @@ const RiscVSmpResponse = extern struct {
     flags: u32,
     bsp_hart_id: u64,
     cpu_count: u64,
-    cpus_ptr: [*]*X86SmpInfo,
+    cpus_ptr: [*]*RiscVSmpInfo,
 
-    pub inline fn cpus(self: *@This()) []*X86SmpInfo {
+    pub inline fn cpus(self: *@This()) []*RiscVSmpInfo {
         return self.cpus_ptr[0..self.cpu_count];
     }
 };


### PR DESCRIPTION
I have already done the change locally, it's needed for being able to actually use the SMP info structure on aarch64 build. Submitting here because I don't like having local changes.