### PR TITLE
Updated to zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *std.Build) void {
     const CreateOptions = std.Build.Module.CreateOptions;
     var options: CreateOptions = .{};
 
-    const root_source_path: std.Build.LazyPath = .{ .path = "limine.zig" };
+    const root_source_path: std.Build.LazyPath = b.path("limine.zig");
     if (@hasField(CreateOptions, "source_file")) {
         options.source_file = root_source_path;
     } else if (@hasField(CreateOptions, "root_source_file")) {


### PR DESCRIPTION
`.{.path = "..."}` was deprecated recently